### PR TITLE
Allow client object to be passed for manager method

### DIFF
--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -54,12 +54,13 @@ class Wrapper
     /**
      * Returns trello manager instance
      *
+     * @param null $client
      * @return \Trello\Manager
      */
-    public function manager()
+    public function manager($client = null)
     {
         if (!isset($this->manager)) {
-            $this->manager = new Manager($this->client);
+            $this->manager = new Manager($client ? $client : $this->client);
         }
 
         return $this->manager;


### PR DESCRIPTION
this **PR** , allows to **inject $client** as **dependency** to **manager method** , which will give more **flexibility** and allows to do something like that

```php
$client = new Client();

$client->authenticate('API KEY','Token', Client::AUTH_URL_CLIENT_ID);

Trello::manager($client);
```

the reason is , i have a users table and each user has his own token